### PR TITLE
Remove dependence on git

### DIFF
--- a/etc.gemspec
+++ b/etc.gemspec
@@ -12,9 +12,21 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/ruby/etc"
   spec.license       = "BSD-2-Clause"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
+  spec.files         = %w[
+    .gitignore
+    .travis.yml
+    Gemfile
+    LICENSE.txt
+    README.md
+    Rakefile
+    bin/console
+    bin/setup
+    etc.gemspec
+    ext/etc/etc.c
+    ext/etc/extconf.rb
+    ext/etc/mkconstants.rb
+    test/etc/test_etc.rb
+  ]
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
About default gem, never depend on git in its build process.
See https://bugs.ruby-lang.org/issues/13423 .