### PR TITLE
Remove taint support

### DIFF
--- a/ext/etc/etc.c
+++ b/ext/etc/etc.c
@@ -100,7 +100,7 @@ static VALUE
 safe_setup_str(const char *str)
 {
     if (str == 0) str = "";
-    return rb_tainted_str_new2(str);
+    return rb_str_new2(str);
 }
 
 static VALUE
@@ -219,7 +219,6 @@ etc_getpwnam(VALUE obj, VALUE nam)
     struct passwd *pwd;
     const char *p = StringValueCStr(nam);
 
-    rb_check_safe_obj(nam);
     pwd = getpwnam(p);
     if (pwd == 0) rb_raise(rb_eArgError, "can't find user for %"PRIsVALUE, nam);
     return setup_passwd(pwd);
@@ -463,7 +462,6 @@ etc_getgrnam(VALUE obj, VALUE nam)
     struct group *grp;
     const char *p = StringValueCStr(nam);
 
-    rb_check_safe_obj(nam);
     grp = getgrnam(p);
     if (grp == 0) rb_raise(rb_eArgError, "can't find group for %"PRIsVALUE, nam);
     return setup_group(grp);
@@ -679,7 +677,10 @@ etc_systmpdir(void)
     }
 # endif
 #endif
+#ifndef RB_PASS_KEYWORDS
+    /* untaint on Ruby < 2.7 */
     FL_UNSET(tmpdir, FL_TAINT);
+#endif
     return tmpdir;
 }
 


### PR DESCRIPTION
Ruby 2.7 deprecates taint and it no longer has an effect.
The lack of taint support should not cause a problem in
previous Ruby versions.

Still untaint the tmpdir object on Ruby <2.7, as returning
a tainted string there could cause problems.