### PR TITLE
Add getgrouplist method to Etc

### DIFF
--- a/ext/etc/extconf.rb
+++ b/ext/etc/extconf.rb
@@ -12,6 +12,7 @@ have_func("uname((struct utsname *)NULL)", headers)
 have_func("getlogin")
 have_func("getpwent")
 have_func("getgrent")
+have_func("getgrouplist")
 if (sysconfdir = RbConfig::CONFIG["sysconfdir"] and
     !RbConfig.expand(sysconfdir.dup, "prefix"=>"", "DESTDIR"=>"").empty?)
   $defs.push("-DSYSCONFDIR=#{Shellwords.escape(sysconfdir.dump)}")

--- a/ext/etc/extconf.rb
+++ b/ext/etc/extconf.rb
@@ -7,12 +7,14 @@ headers = []
     headers << h
   end
 }
+
 have_library("sun", "getpwnam")	# NIS (== YP) interface for IRIX 4
 have_func("uname((struct utsname *)NULL)", headers)
 have_func("getlogin")
 have_func("getpwent")
 have_func("getgrent")
 have_func("getgrouplist")
+have_func("getgrouplist_2") if /darwin/ === RUBY_PLATFORM
 if (sysconfdir = RbConfig::CONFIG["sysconfdir"] and
     !RbConfig.expand(sysconfdir.dup, "prefix"=>"", "DESTDIR"=>"").empty?)
   $defs.push("-DSYSCONFDIR=#{Shellwords.escape(sysconfdir.dump)}")

--- a/ext/etc/extconf.rb
+++ b/ext/etc/extconf.rb
@@ -14,7 +14,6 @@ have_func("getlogin")
 have_func("getpwent")
 have_func("getgrent")
 have_func("getgrouplist")
-have_func("getgrouplist_2") if /darwin/ === RUBY_PLATFORM
 if (sysconfdir = RbConfig::CONFIG["sysconfdir"] and
     !RbConfig.expand(sysconfdir.dup, "prefix"=>"", "DESTDIR"=>"").empty?)
   $defs.push("-DSYSCONFDIR=#{Shellwords.escape(sysconfdir.dump)}")

--- a/test/etc/test_etc.rb
+++ b/test/etc/test_etc.rb
@@ -107,23 +107,18 @@ class TestEtc < Test::Unit::TestCase
   end
 
   def test_getgrouplist
+    return if Etc.getgrouplist(Etc.getpwuid.name) == nil
+
     users = Hash.new {[]}
 
-    # get users
+    # map user to gid
     Etc.passwd do |s|
-      users[s.name] = []
-    end
-
-    # get groups for all users
-    Etc.group do |gr|
-      users.each do |user, _|
-        users[user] |= [gr.name] if gr.mem.include?(user)
-      end
+      users[s.name] = s.gid
     end
 
     # confirm getgrouplist reports the same
-    users.each do |user, groups|
-      assert_equal(groups.sort, Etc.getgrouplist(user).map(&:name).sort)
+    users.each do |user, group|
+      assert_include(Etc.getgrouplist(user), group)
     end
   end
 

--- a/test/etc/test_etc.rb
+++ b/test/etc/test_etc.rb
@@ -117,13 +117,13 @@ class TestEtc < Test::Unit::TestCase
     # get groups for all users
     Etc.group do |gr|
       users.each do |user, _|
-        users[user].append(gr) if gr.mem.include?(user)
+        users[user] |= [gr.name] if gr.mem.include?(user)
       end
     end
 
     # confirm getgrouplist reports the same
     users.each do |user, groups|
-      assert_equal(groups, Etc.getgrouplist(user))
+      assert_equal(groups.sort, Etc.getgrouplist(user).map(&:name).sort)
     end
   end
 

--- a/test/etc/test_etc.rb
+++ b/test/etc/test_etc.rb
@@ -106,6 +106,27 @@ class TestEtc < Test::Unit::TestCase
     end
   end
 
+  def test_getgrouplist
+    users = Hash.new {[]}
+
+    # get users
+    Etc.passwd do |s|
+      users[s.name] = []
+    end
+
+    # get groups for all users
+    Etc.group do |gr|
+      users.each do |user, _|
+        users[user].append(gr) if gr.mem.include?(user)
+      end
+    end
+
+    # confirm getgrouplist reports the same
+    users.each do |user, groups|
+      assert_equal(groups, Etc.getgrouplist(user))
+    end
+  end
+
   def test_group_with_low_level_api
     a = []
     Etc.group {|s| a << s }


### PR DESCRIPTION
Add a `getgrouplist` method to the Etc module, which behaves similarly to the glibc method, with some differences.

The glibc method returns all GIDs for groups a user is part of. It also requires a `gid_t` parameter which is usually the group ID from the user's passwd record.[1]

The Ruby version does the following:
- calls `getpwnam()` to get the gid of the queried user
- calls `getgrouplist()` with the user and gid until something else than -1 is returned
- returns the groups in the form of an array of GIDs

Notes:
- the BSD/Apple implementation requires `ngroups` to be equal or larger than the actual amount of groups, in order for `getgrouplist()` to return the correct number of groups.[2]
- on the Apple implementation, `groups` has the type of `int`, whereas glibc has `gid_t`[3] 
- the `NGROUPS_MAX` limit is not always a hard limit, on OS X 10.15 its value is 8, but more groups can be returned by `getgrouplist`, that's why we keep increasing the `ngroups` value

[1] https://man7.org/linux/man-pages/man3/getgrouplist.3.html
[2] https://www.freebsd.org/cgi/man.cgi?query=getgrouplist&sektion=3&apropos=0&manpath=freebsd
[3] https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/getgrouplist.3.html

Signed-off-by: Gabriel Nagy <gabriel.nagy@puppet.com>