### PR TITLE
CI: use bundler-cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Install dependencies
-      run: |
-        gem install bundler --no-document
-        bundle install
+        bundler-cache: true
+    # Avoid issues on these platforms
+    - if: ${{ matrix.ruby == '2.5' || matrix.ruby == '2.6' }}
+      run: gem update --system
     - name: Run test
-      run: rake compile test
+      run: bundle exec rake compile test

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in etc.gemspec
 gemspec
+
+# Ensure a new-enough version of fileutils is used in tests,
+# to avoid a gem activation issue, which affected Ruby 2.6, 2.5.
+# https://github.com/ruby/etc/pull/14#issuecomment-989742427
+gem 'fileutils', '>= 1.2.0'


### PR DESCRIPTION
This PR uses the `bundler-cache` feature of the Ruby-maintained Action `ruby/setup-ruby`.

[See `ruby/setup-ruby` parameters declaration](https://github.com/ruby/setup-ruby/blob/master/action.yml) for more information.

---

In order to get this to run green:

- Use the newest-possible RubyGems for old Ruby versions
- Use a newer-than-troublesome version of `fileutils` gem when running tests
