### PR TITLE
Remove usage of IO internals.

### DIFF
--- a/ext/etc/etc.c
+++ b/ext/etc/etc.c
@@ -66,6 +66,15 @@ void rb_deprecate_constant(VALUE mod, const char *name);
 
 #include "constdefs.h"
 
+#ifndef HAVE_RB_IO_DESCRIPTOR
+static int
+rb_io_descriptor(VALUE io) {
+    rb_io_t *fptr;
+    GetOpenFile(io, fptr);
+    return fptr->fd;
+}
+#endif
+
 #ifdef HAVE_RUBY_ATOMIC_H
 # include "ruby/atomic.h"
 #else
@@ -941,14 +950,11 @@ io_pathconf(VALUE io, VALUE arg)
 {
     int name;
     long ret;
-    rb_io_t *fptr;
 
     name = NUM2INT(arg);
 
-    GetOpenFile(io, fptr);
-
     errno = 0;
-    ret = fpathconf(fptr->fd, name);
+    ret = fpathconf(rb_io_descriptor(io), name);
     if (ret == -1) {
         if (errno == 0) /* no limit */
             return Qnil;

--- a/ext/etc/extconf.rb
+++ b/ext/etc/extconf.rb
@@ -50,6 +50,8 @@ end
 # TODO: remove when dropping 2.7 support, as exported since 3.0
 have_func('rb_deprecate_constant(Qnil, "None")')
 
+have_func("rb_io_descriptor")
+
 $distcleanfiles << "constdefs.h"
 
 create_makefile("etc")


### PR DESCRIPTION
See <https://github.com/ruby/ruby/pull/6511> for more details.

cc @KJTsanaktsidis