### PR TITLE
Add TruffleRuby in CI and use the correct fallback pattern for rb_io_descriptor()

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
       matrix:
-        ruby: [ '3.1', '3.0', '2.7', '2.6', head ]
+        ruby: [ '3.1', '3.0', '2.7', '2.6', head, truffleruby, truffleruby-head ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/ext/etc/etc.c
+++ b/ext/etc/etc.c
@@ -68,11 +68,12 @@ void rb_deprecate_constant(VALUE mod, const char *name);
 
 #ifndef HAVE_RB_IO_DESCRIPTOR
 static int
-rb_io_descriptor(VALUE io) {
+io_descriptor_fallback(VALUE io) {
     rb_io_t *fptr;
     GetOpenFile(io, fptr);
     return fptr->fd;
 }
+#define rb_io_descriptor io_descriptor_fallback
 #endif
 
 #ifdef HAVE_RUBY_ATOMIC_H


### PR DESCRIPTION
Follow-up of https://github.com/ruby/etc/pull/26, cc @ioquatix 

Adding TruffleRuby in CI will prevent unintended regressions like #26.
TruffleRuby uses this C extension to implement `etc`.