### PR TITLE
Fix inconsistent dll linkage warning

### DIFF
--- a/ext/etc/etc.c
+++ b/ext/etc/etc.c
@@ -54,7 +54,7 @@ static VALUE sGroup;
 #  include <stdlib.h>
 # endif
 #endif
-char *getlogin(void);
+RUBY_EXTERN char *getlogin(void);
 
 #define RUBY_ETC_VERSION "1.4.3.dev.1"
 


### PR DESCRIPTION
https://github.com/ruby/ruby/actions/runs/6758843165/job/18370890970#step:18:1050
```
../../../src/ext/etc/etc.c(57): warning C4273: 'getlogin': inconsistent dll linkage
D:\a\ruby\ruby\src\include\ruby/missing.h(264): note: see previous definition of 'getlogin'
```