### PR TITLE
Add parsing /etc/os-release file

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ extask = Rake::ExtensionTask.new(name) do |x|
   x.lib_dir.sub!(%r[(?=/|\z)], "/#{RUBY_VERSION}/#{x.platform}")
 end
 Rake::TestTask.new(:test) do |t|
-  t.libs = ["lib/#{RUBY_VERSION}/#{extask.platform}"]
+  t.libs << extask.lib_dir
   t.libs << "test/lib"
   t.ruby_opts << "-rhelper"
   t.test_files = FileList["test/**/test_*.rb"]

--- a/etc.gemspec
+++ b/etc.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
     ext/etc/etc.c
     ext/etc/extconf.rb
     ext/etc/mkconstants.rb
+    lib/etc.rb
     test/etc/test_etc.rb
   ] + changelogs
   spec.rdoc_options = ["--main", "README.md"]

--- a/lib/etc.rb
+++ b/lib/etc.rb
@@ -1,0 +1,61 @@
+# frozen-string-literal: true
+
+require 'etc.so'
+require 'shellwords'
+
+module Etc
+  #
+  # Parses the +os-release+ file to return a hash like
+  # <code>{ :NAME => "Fedora Linux", ... }</code>.
+  #
+  # Parsing is done according to the Bourne shell word rules, but no
+  # shell expansion of any kind is performed and variables with empty
+  # values are discarded.
+  #
+  # With no arguments, looks for the +os-release+ file in +/etc+ (and
+  # a couple of other places). With arguments, goes through each one
+  # of them until the first successful parse.
+  #
+  # If the host OS is Linux _and_ keys +:NAME+, +:ID+, or
+  # +:PRETTY_NAME+ are undefined in the file, sets them to the default
+  # standard values according to the Freedesktop specification.
+  #
+  # Raises a +RuntimeError+ if no file is successfully parsed or
+  # an error from +Shellwords+ module in case of syntax problems.
+  #
+  def self.freedesktop_os_release *src
+    defvars = RUBY_PLATFORM =~ /linux/i ? Freedesktop::LINUX_DEFAULS : {}
+
+    (src.length == 0 ? Freedesktop::FILES : src).each do |file|
+      text = File.read(file) rescue nil
+      if text
+        begin
+          return defvars.merge Freedesktop.os_release_parse_str(text)
+        rescue
+          fail "Parsing `#{file}` failed"
+        end
+      end
+    end
+
+    fail "No suitable sources"
+  end
+
+  class Freedesktop # :nodoc:
+    FILES = ['/etc/os-release', '/usr/lib/os-release', '/etc/initrd-release']
+    LINUX_DEFAULS = {
+      :NAME => "Linux",
+      :ID => "linux",
+      :PRETTY_NAME => "Linux",
+    }
+
+    def self.os_release_parse_str s
+      valid_name = /^(?![0-9])[a-zA-Z0-9_]+$/
+      s.split($/)
+        .map { |line| Shellwords.split(line).first&.split('=') }
+        .filter { |v| v && v.length > 1 && v.first =~ valid_name }
+        .map { |v| [v.first.upcase.to_sym, v[1..-1].join('=')] }
+        .to_h
+    end
+  end
+
+end


### PR DESCRIPTION
Why?

* First of all, because [`os-release`][] is a file that resides in /etc.

* Second, the majority of Linux distros that are > 10 y.o. have it (including non-systemd-based ones).

* Even [FreeBSD adopted it][] in 2021 with release 13.

* Python has [`platform.freedesktop_os_release()`][] in its stdlib since v3.10 (2021).

* `os` rubygem contains the function that parses it, but poorly adheres to the os-release spec; for instance, does not ignore comments, does not unescape shell-escaped chars, &c.

* I think such a basic thing should be in the Ruby stdlib.

[`os-release`]: https://www.freedesktop.org/software/systemd/man/latest/os-release.html

[FreeBSD adopted it]: https://man.freebsd.org/cgi/man.cgi?query=os-release&apropos=0&sektion=0&manpath=FreeBSD+13.0-RELEASE&arch=default&format=html

[`platform.freedesktop_os_release()`]: https://docs.python.org/3.13/library/platform.html#platform.freedesktop_os_release

While searching through Github for how people parse this file, there are 3 camps:

1. shell:

       `source "/etc/os-release" && echo $ID`.chomp == 'fedora'

   which is simple but unsafe security-wise;

2. shell with an external commands like grep & sed;

3. ad hoc strategies: split by a newline then by '=' and remove surrounding quotes, or extract key-value pairs with a regex.

I propose this: parse os-release using Shellwords module, allow a user to parse it from any location, not just /etc, pre-fill the result with the defaults according to the Freedesktop spec.