### PR TITLE
Fix sysconfdir when load-relative

### DIFF
--- a/ext/etc/etc.c
+++ b/ext/etc/etc.c
@@ -691,6 +691,16 @@ etc_getgrent(VALUE obj)
 VALUE rb_w32_special_folder(int type);
 UINT rb_w32_system_tmpdir(WCHAR *path, UINT len);
 VALUE rb_w32_conv_from_wchar(const WCHAR *wstr, rb_encoding *enc);
+#elif defined(LOAD_RELATIVE)
+static inline VALUE
+rbconfig(void)
+{
+    VALUE config;
+    rb_require("rbconfig");
+    config = rb_const_get(rb_path2class("RbConfig"), rb_intern("CONFIG"));
+    Check_Type(config, T_HASH);
+    return config;
+}
 #endif
 
 /* call-seq:
@@ -710,6 +720,8 @@ etc_sysconfdir(VALUE obj)
 {
 #ifdef _WIN32
     return rb_w32_special_folder(CSIDL_COMMON_APPDATA);
+#elif defined(LOAD_RELATIVE)
+    return rb_hash_aref(rbconfig(), rb_str_new_lit("sysconfdir"));
 #else
     return rb_filesystem_str_new_cstr(SYSCONFDIR);
 #endif

--- a/test/etc/test_etc.rb
+++ b/test/etc/test_etc.rb
@@ -169,6 +169,10 @@ class TestEtc < Test::Unit::TestCase
     assert_operator(1, :<=, n)
   end
 
+  def test_sysconfdir
+    assert_operator(File, :absolute_path?, Etc.sysconfdir)
+  end if File.method_defined?(:absolute_path?)
+
   def test_ractor
     return unless Etc.passwd # => skip test if no platform support
     Etc.endpwent


### PR DESCRIPTION
When relative load paths option is enabled, the prefix is determined at the runtime.  The only way to get it outside libruby is to use rbconfig.rb.