### PR TITLE
Etc is not Ractor-safe currently

### DIFF
--- a/ext/etc/etc.c
+++ b/ext/etc/etc.c
@@ -1163,14 +1163,27 @@ Init_etc(void)
 {
     VALUE mEtc;
 
-#ifdef HAVE_RB_EXT_RACTOR_SAFE
-    RB_EXT_RACTOR_SAFE(true);
-#endif
     mEtc = rb_define_module("Etc");
     /* The version */
     rb_define_const(mEtc, "VERSION", rb_str_new_cstr(RUBY_ETC_VERSION));
     init_constants(mEtc);
 
+    /* Ractor-safe methods */
+#ifdef HAVE_RB_EXT_RACTOR_SAFE
+    RB_EXT_RACTOR_SAFE(true);
+#endif
+    rb_define_module_function(mEtc, "sysconfdir", etc_sysconfdir, 0);
+    rb_define_module_function(mEtc, "systmpdir", etc_systmpdir, 0);
+    rb_define_module_function(mEtc, "uname", etc_uname, 0);
+    rb_define_module_function(mEtc, "sysconf", etc_sysconf, 1);
+    rb_define_module_function(mEtc, "confstr", etc_confstr, 1);
+    rb_define_method(rb_cIO, "pathconf", io_pathconf, 1);
+    rb_define_module_function(mEtc, "nprocessors", etc_nprocessors, 0);
+
+    /* Non-Ractor-safe methods, see https://bugs.ruby-lang.org/issues/21115 */
+#ifdef HAVE_RB_EXT_RACTOR_SAFE
+    RB_EXT_RACTOR_SAFE(false);
+#endif
     rb_define_module_function(mEtc, "getlogin", etc_getlogin, 0);
 
     rb_define_module_function(mEtc, "getpwuid", etc_getpwuid, -1);
@@ -1186,13 +1199,6 @@ Init_etc(void)
     rb_define_module_function(mEtc, "setgrent", etc_setgrent, 0);
     rb_define_module_function(mEtc, "endgrent", etc_endgrent, 0);
     rb_define_module_function(mEtc, "getgrent", etc_getgrent, 0);
-    rb_define_module_function(mEtc, "sysconfdir", etc_sysconfdir, 0);
-    rb_define_module_function(mEtc, "systmpdir", etc_systmpdir, 0);
-    rb_define_module_function(mEtc, "uname", etc_uname, 0);
-    rb_define_module_function(mEtc, "sysconf", etc_sysconf, 1);
-    rb_define_module_function(mEtc, "confstr", etc_confstr, 1);
-    rb_define_method(rb_cIO, "pathconf", io_pathconf, 1);
-    rb_define_module_function(mEtc, "nprocessors", etc_nprocessors, 0);
 
     sPasswd =  rb_struct_define_under(mEtc, "Passwd",
 				      "name",


### PR DESCRIPTION
* See https://bugs.ruby-lang.org/issues/21115
* Fixes #50 

I think this makes sense for now to address the segfault.
Of course it can be improved later to use explicit locking.