### PR TITLE
Skip TestEtc#test_ractor_parallel on ModGC workflow

### DIFF
--- a/test/etc/test_etc.rb
+++ b/test/etc/test_etc.rb
@@ -175,6 +175,8 @@ class TestEtc < Test::Unit::TestCase
 
   # All Ractor-safe methods should be tested here
   def test_ractor_parallel
+    omit "This test is flaky and intermittently failing now on ModGC workflow" if ENV['GITHUB_WORKFLOW'] == 'ModGC'
+
     assert_ractor(<<~RUBY, require: 'etc', timeout: 60)
       10.times.map do
         Ractor.new do


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/21204

TestEtc#test_ractor_parallel is only failing intermittently on ModGC workflow after https://github.com/ruby/etc/commit/87fb0c4a8386a19b57d1fc2915e0466f9b6a01bd. So, we'll skip this test on ModGC workflow.